### PR TITLE
feat: list Lightning Email Templates and Folders

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -3,6 +3,9 @@
   "edition": "Developer",
   "features": [],
   "settings": {
+    "emailTemplateSettings": {
+      "enableTemplateEnhancedFolderPref": true
+    },
     "lightningExperienceSettings": {
       "enableS1DesktopEnabled": true
     },

--- a/force-app/main/default/email/Foo.emailFolder-meta.xml
+++ b/force-app/main/default/email/Foo.emailFolder-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EmailTemplateFolder xmlns="http://soap.sforce.com/2006/04/metadata">
+    <folderShares>
+        <accessLevel>Manage</accessLevel>
+        <sharedTo>test-yuanuy75bflc@example.com</sharedTo>
+        <sharedToType>User</sharedToType>
+    </folderShares>
+    <name>Foo</name>
+</EmailTemplateFolder>

--- a/force-app/main/default/email/Foo/Bar.emailFolder-meta.xml
+++ b/force-app/main/default/email/Foo/Bar.emailFolder-meta.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EmailTemplateFolder xmlns="http://soap.sforce.com/2006/04/metadata">
+    <name>Bar</name>
+</EmailTemplateFolder>

--- a/force-app/main/default/email/Foo/Bar/Baz_1645201301610.email-meta.xml
+++ b/force-app/main/default/email/Foo/Bar/Baz_1645201301610.email-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EmailTemplate xmlns="http://soap.sforce.com/2006/04/metadata">
+    <available>true</available>
+    <encodingKey>UTF-8</encodingKey>
+    <name>Baz</name>
+    <relatedEntityType>Account</relatedEntityType>
+    <style>none</style>
+    <subject>Baz</subject>
+    <type>custom</type>
+    <uiType>SFX</uiType>
+</EmailTemplate>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -7,5 +7,5 @@
   ],
   "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "50.0"
+  "sourceApiVersion": "53.0"
 }

--- a/src/metadata-lister/folderbased.ts
+++ b/src/metadata-lister/folderbased.ts
@@ -9,6 +9,9 @@ import MetadataLister from '../metadata-lister';
 
 export const FOLDER_BASED_METADATA_MAP = {
   EmailFolder: 'EmailTemplate',
+  // Attention: DescribeMetadataResult does not list EmailTemplateFolder (for Lightning Email Templates as Metadata Type)
+  // The only reference of EmailTemplateFolder is in the Metadata Coverage Report https://developer.salesforce.com/docs/metadata-coverage/54/EmailTemplateFolder/details
+  EmailTemplateFolder: 'EmailTemplate',
   DashboardFolder: 'Dashboard',
   DocumentFolder: 'Document',
   ReportFolder: 'Report'

--- a/test/folderbased.e2e-spec.ts
+++ b/test/folderbased.e2e-spec.ts
@@ -5,6 +5,10 @@ import FolderBasedMetadata from '../src/metadata-lister/folderbased';
 
 const expected = [
   'EmailFolder:unfiled$public',
+  'EmailTemplate:Bar/Baz_1645201301610',
+  'EmailTemplateFolder:Bar',
+  'EmailTemplateFolder:Foo',
+  'EmailTemplateFolder:unfiled$public',
   'Report:FooReports/FooAccountsClassicReport',
   'Report:FooReports/FooAccountsLightningReport_vgv',
   'Report:FooSubReports/FooAccountsSubLightningReport_kgv',


### PR DESCRIPTION
Unfortunately the Metadata Type EmailTemplateFolder is not mentioned in the DescribeMetadataResult.

sfdx force:mdapi:describemetadata | grep EmailTemplateFolder

And so there were no Lightning EmailTemplates listed when using

sfdx force:mdapi:listallmetadata --folderbased

Thank you @ChristianMenzinger for the hint.