### PR TITLE
fix: omit pure container types for --children flag

### DIFF
--- a/src/commands/force/mdapi/listallmetadata.ts
+++ b/src/commands/force/mdapi/listallmetadata.ts
@@ -175,6 +175,10 @@ export default class MdapiListAllMetadataCommand extends SfdxCommand {
         }
       }
     }
+    if (this.flags.children) {
+      // omit parent types which don't have own properties
+      ignoreFunctions.push(filters.isPureContainerType);
+    }
     let fileProperties = await listAllMetadata(
       conn,
       this.flags,

--- a/src/commands/package.xml/generate.ts
+++ b/src/commands/package.xml/generate.ts
@@ -89,12 +89,6 @@ export default class PackageXmlGenerateCommand extends SfdxCommand {
     if (this.flags.defaultignore) {
       ignorePatterns.push(...this.flags.defaultignore);
     }
-    // don't list 'CustomLabels:CustomLabels' if specific 'CustomLabel:XXX' are given
-    if (fileProperties.find((fp) => fp.type === 'CustomLabel') !== null) {
-      fileProperties = fileProperties.filter(
-        (fp) => fp.type !== 'CustomLabels'
-      );
-    }
     const [, keep] = match(
       fileProperties,
       ignorePatterns,

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -21,6 +21,18 @@ const MANAGED_READONLY_TYPES = [
   'ApexPage'
 ];
 
+// parent types which don't have own properties
+const PURE_CONTAINER_TYPES = [
+  'AssignmentRules',
+  'AutoResponseRules',
+  'CustomLabels',
+  'EscalationRules',
+  'ManagedTopics',
+  'MatchingRules',
+  'SharingRules',
+  'Workflow'
+];
+
 const STANDARD_USERNAMES = ['Automated Process', 'salesforce.com'];
 
 export function isManaged(fileProperties: FileProperties): boolean {
@@ -75,4 +87,8 @@ export function isStandard(fileProperties: FileProperties): boolean {
       STANDARD_USERNAMES.includes(fileProperties.lastModifiedByName)) ||
     fileProperties.namespacePrefix === 'standard'
   );
+}
+
+export function isPureContainerType(fileProperties: FileProperties): boolean {
+  return PURE_CONTAINER_TYPES.includes(fileProperties.type);
 }


### PR DESCRIPTION
Some parent types are only a container for their children.
These parent types shouldn't be retrieved because they lack control.
Instead use the addressable child types.

Examples:

- omit CustomLabels in favor of CustomLabel
- omit Workflow in favor of WorkflowAlert, etc
- but use CustomObject because it has own properties like description, etc